### PR TITLE
Add Darwin support to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,18 +16,18 @@
           version = "1.0.0";
 
           src = ./.;
-          vendorHash = "sha256-UB/V4CO1YxqjNvROhCJAyWa3q79YrvkWa1R2sdSf8Zo=";
+          vendorHash = "sha256-CjEFbHnf6x1ebrIuWiNelEWI7E2CC4vrQo86gJ1+wQU=";
 
           meta = with pkgs.lib; {
             description = "Bluetooth Low Energy advertisement data sniffer";
             homepage = "https://github.com/nxm/bluetooth-sniffer";
             license = licenses.mit;
-            platforms = platforms.linux;
+            platforms = platforms.linux ++ platforms.darwin;
           };
 
-          buildInputs = with pkgs; [
-            bluez
-          ];
+          # BlueZ is the Linux BLE stack; on Darwin the cbgo backend links
+          # against the system CoreBluetooth framework instead.
+          buildInputs = pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.bluez ];
         };
       in
       {
@@ -46,8 +46,7 @@
             gopls
             go-tools
             golangci-lint
-            bluez
-          ];
+          ] ++ lib.optionals stdenv.isLinux [ bluez ];
         };
       }
     );


### PR DESCRIPTION
## Problem

`nix run github:nxm/bluetooth-sniffer` on macOS (arm64-apple-darwin) fails:

```
error: Package 'bluetooth-sniffer-1.0.0' ... is not available on the requested hostPlatform:
  hostPlatform.config = "arm64-apple-darwin"
  package.meta.platforms = [ "aarch64-linux" ... ]
```

Two causes:
1. `meta.platforms = platforms.linux` refuses evaluation on Darwin.
2. `buildInputs = [ bluez ]` — BlueZ is the Linux-only BLE stack.

## Fix

- Extend `meta.platforms` to include Darwin.
- Gate `bluez` behind `stdenv.isLinux` (build + devShell). On Darwin the tinygo bluetooth backend links against the system CoreBluetooth framework via `github.com/tinygo-org/cbgo`, so BlueZ is neither needed nor available.
- Refresh `vendorHash`, stale after the tinygo bluetooth 0.13.0 bump (Go module hash is platform-independent, still valid on Linux).

## Verified

`nix build .#bluetooth-sniffer` succeeds on arm64-darwin; `./result/bin/bluetooth-sniffer --help` exits 0.